### PR TITLE
Update MCI driver for the first version of the SDMMC peripheral

### DIFF
--- a/Drivers/MCI_STM32.c
+++ b/Drivers/MCI_STM32.c
@@ -62,6 +62,14 @@ This driver requires the following configuration in CubeMX:
       - enabled **SDIO global interrupt** with **Generate Enable in Init** and without **Generate IRQ handler**
       - enabled **SDIO_RX** and **SDIO_TX** DMA Requests that **Call HAL handlers**.
 
+  - Optionaly Card Detect or Write Protect pin may be configured:
+    - Chose any general purpose pin as input and add **User Label**:
+      - MemoryCard_1_CD to add Card Detect pin for SDMMC1 or SDIO
+      - MemoryCard_1_WP to add Write Protect pin for SDMMC1
+    - Analogues for SDMMC2 add **User Label** as below:
+      - MemoryCard_2_CD
+      - MemoryCard_2_WP
+
 > **Notes**
 >
 > - configuration information in the **MX_Device.h** file is based on CubeMX configuration.
@@ -71,6 +79,11 @@ This driver requires the following configuration in CubeMX:
 >   is called and that memory containing received data is updated after the reception finishes (**cache invalidate**).
 > - some DMA controllers can only access specific memories, so ensure that proper memory is used for the buffers
 >   according to the DMA requirement.
+
+When **peripheral is configured for MMC** in CubeMX (regardles of peripheral type):
+
+  - When using SDMMC1 or SDIO define **MemoryCard_1_MMC** in your project when compiling this module
+  - When using SDMMC2 define **MemoryCard_2_MMC** in your project when compiling this module
 
 ## Example
 
@@ -168,7 +181,7 @@ This driver requires the following configuration in CubeMX:
 
 
 /**
-  \brief MCI1: Define MemoryCard_MMC1 if STM32CubeMX configures SDMMC1 for MMC device
+  \brief MCI1: Define MemoryCard_1_MMC if STM32CubeMX configures SDMMC1 for MMC device
 */
 #if !defined(MemoryCard_1_MMC)
   #define MCI1_HANDLE_TYPE              0U
@@ -177,7 +190,7 @@ This driver requires the following configuration in CubeMX:
 #endif
 
 /**
-  \brief MCI2: Define MemoryCard_MMC2 if STM32CubeMX configures SDMMC2 for MMC device
+  \brief MCI2: Define MemoryCard_2_MMC if STM32CubeMX configures SDMMC2 for MMC device
 */
 #if !defined(MemoryCard_2_MMC)
   #define MCI2_HANDLE_TYPE              0U
@@ -297,6 +310,23 @@ static MCIn_SECTION(0) MCI_INFO MCI1_Info = {
   0U
 };
 
+#if defined(MCI_DMA_EXT)
+extern DMA_HandleTypeDef hdma_sdmmc1_rx;
+extern DMA_HandleTypeDef hdma_sdmmc1_tx;
+
+static void MCI1_RX_DMA_Complete(DMA_HandleTypeDef *hdma);
+
+static MCI_DMA MCI1_RxDma = {
+  &hdma_sdmmc1_rx,
+  &MCI1_RX_DMA_Complete
+};
+
+static MCI_DMA MCI1_TxDma = {
+  &hdma_sdmmc1_tx,
+  NULL
+};
+#endif
+
 /* MCI1 Resources */
 static MCI_RESOURCES MCI1 = {
   MCI1_HAL_MSPINIT,
@@ -318,9 +348,20 @@ static MCI_RESOURCES MCI1 = {
   #else
   { NULL, 0U, 0U },
   #endif
+  #if defined(MCI_DMA_EXT)
+  MCI1_RxDma,
+  MCI1_TxDma,
+  #endif
   MCI1_CFG,
   &MCI1_Info
 };
+
+#if defined(MCI_DMA_EXT)
+/* DMA RX complete callback */
+static void MCI1_RX_DMA_Complete(DMA_HandleTypeDef *hdma) {
+  RX_DMA_Complete (hdma, &MCI1);
+}
+#endif
 
 #endif /* MCI1_ENABLE */
 
@@ -335,6 +376,23 @@ static MCIn_SECTION(0) MCI_INFO MCI2_Info = {
   0U,
   0U
 };
+
+#if defined(MCI_DMA_EXT)
+extern DMA_HandleTypeDef hdma_sdmmc2_rx;
+extern DMA_HandleTypeDef hdma_sdmmc2_tx;
+
+static void MCI2_RX_DMA_Complete(DMA_HandleTypeDef *hdma);
+
+static MCI_DMA MCI2_RxDma = {
+  &hdma_sdmmc2_rx,
+  &MCI2_RX_DMA_Complete
+};
+
+static MCI_DMA MCI2_TxDma = {
+  &hdma_sdmmc2_tx,
+  NULL
+};
+#endif
 
 /* MCI2 Resources */
 static MCI_RESOURCES MCI2 = {
@@ -357,9 +415,20 @@ static MCI_RESOURCES MCI2 = {
   #else
   { NULL, 0U, 0U },
   #endif
+  #if defined(MCI_DMA_EXT)
+  MCI2_RxDma,
+  MCI2_TxDma,
+  #endif
   MCI2_CFG,
   &MCI2_Info
 };
+
+#if defined(MCI_DMA_EXT)
+/* DMA RX complete callback */
+static void MCI2_RX_DMA_Complete(DMA_HandleTypeDef *hdma) {
+  RX_DMA_Complete (hdma, &MCI2);
+}
+#endif
 
 #endif /* MCI2_ENABLE */
 
@@ -705,9 +774,9 @@ static int32_t PowerControl (ARM_POWER_STATE state, MCI_RESOURCES *mci) {
 
       /* Set transceiver polarity */
       if (mci->cfg & MCI_CFG_DIR_POLARITY) {
-        MCI_Set_DirIOPolarity(mci, MCI_DIR_IO_OUT_HIGH);
+        MCI_Set_DirIOPolarity_High(mci);
       } else {
-        MCI_Set_DirIOPolarity(mci, MCI_DIR_IO_OUT_LOW);
+        MCI_Set_DirIOPolarity_Low(mci);
       }
 
       /* Set maximum clock divider */
@@ -742,7 +811,7 @@ static int32_t CardPower (uint32_t voltage, MCI_RESOURCES *mci) {
   if (mci->reg == MCI1_REG_BLOCK) { instance = 1U; }
 #endif
 #if MCI2_ENABLE
-  if (mci->reg == MCI1_REG_BLOCK) { instance = 2U; }
+  if (mci->reg == MCI2_REG_BLOCK) { instance = 2U; }
 #endif
 
   val = MCI_CardPower(instance, voltage);
@@ -766,7 +835,7 @@ static int32_t ReadCD (MCI_RESOURCES *mci) {
   if (mci->reg == MCI1_REG_BLOCK) { instance = 1U; }
 #endif
 #if MCI2_ENABLE
-  if (mci->reg == MCI1_REG_BLOCK) { instance = 2U; }
+  if (mci->reg == MCI2_REG_BLOCK) { instance = 2U; }
 #endif
 
   val = MCI_ReadCD(instance);
@@ -790,7 +859,7 @@ static int32_t ReadWP (MCI_RESOURCES *mci) {
   if (mci->reg == MCI1_REG_BLOCK) { instance = 1U; }
 #endif
 #if MCI2_ENABLE
-  if (mci->reg == MCI1_REG_BLOCK) { instance = 2U; }
+  if (mci->reg == MCI2_REG_BLOCK) { instance = 2U; }
 #endif
 
   val = MCI_ReadWP(instance);
@@ -1019,37 +1088,37 @@ static int32_t Control (uint32_t control, uint32_t arg, MCI_RESOURCES *mci) {
       switch (arg) {
         case ARM_MCI_BUS_DEFAULT_SPEED:
           /* Speed mode up to 25MHz */
-          if (MCI_Set_BusSpeedMode(mci, MCI_BUS_SPEED_MODE_DS) == ARM_DRIVER_OK) {
+          if (MCI_Set_BusSpeedMode_DS(mci) == ARM_DRIVER_OK) {
             break;
           }
         case ARM_MCI_BUS_HIGH_SPEED:
           /* Speed mode up to 50MHz */
-          if (MCI_Set_BusSpeedMode(mci, MCI_BUS_SPEED_MODE_HS) == ARM_DRIVER_OK) {
+          if (MCI_Set_BusSpeedMode_HS(mci) == ARM_DRIVER_OK) {
             break;
           }
         case ARM_MCI_BUS_UHS_SDR12:
           /* SDR12:  up to  25MHz,  12.5MB/s: UHS-I 1.8V signaling */
-          if (MCI_Set_BusSpeedMode(mci, MCI_BUS_SPEED_MODE_SDR12) == ARM_DRIVER_OK) {
+          if (MCI_Set_BusSpeedMode_SDR12(mci) == ARM_DRIVER_OK) {
             break;
           }
         case ARM_MCI_BUS_UHS_SDR25:
           /* SDR25:  up to  50MHz,  25  MB/s: UHS-I 1.8V signaling */
-          if (MCI_Set_BusSpeedMode(mci, MCI_BUS_SPEED_MODE_SDR25) == ARM_DRIVER_OK) {
+          if (MCI_Set_BusSpeedMode_SDR25(mci) == ARM_DRIVER_OK) {
             break;
           }
         case ARM_MCI_BUS_UHS_SDR50:
           /* SDR50:  up to 100MHz,  50  MB/s: UHS-I 1.8V signaling */
-          if (MCI_Set_BusSpeedMode(mci, MCI_BUS_SPEED_MODE_SDR50) == ARM_DRIVER_OK) {
+          if (MCI_Set_BusSpeedMode_SDR50(mci) == ARM_DRIVER_OK) {
             break;
           }
         case ARM_MCI_BUS_UHS_SDR104:
           /* SDR104: up to 208MHz, 104  MB/s: UHS-I 1.8V signaling */
-          if (MCI_Set_BusSpeedMode(mci, MCI_BUS_SPEED_MODE_SDR104) == ARM_DRIVER_OK) {
+          if (MCI_Set_BusSpeedMode_SDR104(mci) == ARM_DRIVER_OK) {
             break;
           }
         case ARM_MCI_BUS_UHS_DDR50:
           /* DDR50:  up to  50MHz,  50  MB/s: UHS-I 1.8V signaling */
-          if (MCI_Set_BusSpeedMode(mci, MCI_BUS_SPEED_MODE_DDR50) == ARM_DRIVER_OK) {
+          if (MCI_Set_BusSpeedMode_DDR50(mci) == ARM_DRIVER_OK) {
             break;
           }
 
@@ -1229,12 +1298,21 @@ static void MCI_IRQHandler (MCI_RESOURCES *mci) {
   }
   if (sta & MCI_IT_DATAEND) {
     icr |= MCI_IT_DATAEND;
+    #if !defined(MCI_DMA_EXT)
     /* Data end (DCOUNT is zero) */
     event |= ARM_MCI_EVENT_TRANSFER_COMPLETE;
+    #endif
   }
   if (sta & MCI_IT_DBCKEND) {
     icr |= MCI_IT_DBCKEND;
     /* Data block sent/received (CRC check passed) */
+    #if defined(MCI_DMA_EXT)
+    if ((mci->info->flags & MCI_DATA_READ) == 0) {
+      /* Write transfer */
+      event |= ARM_MCI_EVENT_TRANSFER_COMPLETE;
+    }
+    #endif
+    
   }
   if (sta & MCI_IT_SDIOIT) {
     icr |= MCI_IT_SDIOIT;

--- a/Drivers/MCI_STM32.c
+++ b/Drivers/MCI_STM32.c
@@ -49,24 +49,24 @@ This driver requires the following configuration in CubeMX:
   - When using SDMMC peripheral:
     - **clock**: **SDMMC*** peripheral clock.
     - **peripheral**: **SDMMC** peripheral configured in **SD** or **MMC** mode.
-    - **pins**: **CMD**, **CK**, **D0** - **D3** and for 8-bit MMC optionaly **D4** - **D7**.
+    - **pins**: **CMD**, **CK**, **D0** - **D3** and for 8-bit MMC optionally **D4** - **D7**.
     - **interrupts**:
       - enabled **SDMMC global interrupt** with **Generate Enable in Init** and without **Generate IRQ handler**
 
   - When using SDIO peripheral:
     - **clock**: **SDIO** peripheral clock.
     - **peripheral**: **SDIO** peripheral configured in **SD** or **MMC** mode.
-    - **pins**: **CMD**, **CK**, **D0** - **D3** and for 8-bit MMC optionaly **D4** - **D7**.
+    - **pins**: **CMD**, **CK**, **D0** - **D3** and for 8-bit MMC optionally **D4** - **D7**.
     - **DMA**: **DMA** stream configuration.
     - **interrupts**:
       - enabled **SDIO global interrupt** with **Generate Enable in Init** and without **Generate IRQ handler**
       - enabled **SDIO_RX** and **SDIO_TX** DMA Requests that **Call HAL handlers**.
 
-  - Optionaly Card Detect or Write Protect pin may be configured:
+  - Optionally Card Detect or Write Protect pin may be configured:
     - Chose any general purpose pin as input and add **User Label**:
       - MemoryCard_1_CD to add Card Detect pin for SDMMC1 or SDIO
       - MemoryCard_1_WP to add Write Protect pin for SDMMC1
-    - Analogues for SDMMC2 add **User Label** as below:
+    - Similar for SDMMC2, add **User Label** as below:
       - MemoryCard_2_CD
       - MemoryCard_2_WP
 
@@ -80,7 +80,7 @@ This driver requires the following configuration in CubeMX:
 > - some DMA controllers can only access specific memories, so ensure that proper memory is used for the buffers
 >   according to the DMA requirement.
 
-When **peripheral is configured for MMC** in CubeMX (regardles of peripheral type):
+When **peripheral is configured for MMC** in CubeMX (regardless of peripheral type):
 
   - When using SDMMC1 or SDIO define **MemoryCard_1_MMC** in your project when compiling this module
   - When using SDMMC2 define **MemoryCard_2_MMC** in your project when compiling this module
@@ -451,7 +451,7 @@ static void Assign_SDMMC_Instance (uint32_t set, MCI_RESOURCES *mci) {
   if (mci == &MCI1) {
     #if (MCI1_HANDLE_TYPE == 0)
       h_sd = (SD_HandleTypeDef *)mci->h;
-      /* Instance is the coresponding peripheral register inteface */
+      /* Instance is the corresponding peripheral register interface */
       if (set == 0) {
         h_sd->Instance = NULL;
       } else {
@@ -459,7 +459,7 @@ static void Assign_SDMMC_Instance (uint32_t set, MCI_RESOURCES *mci) {
       }
     #else
       h_mmc = (MMC_HandleTypeDef *)mci->h;
-      /* Instance is the coresponding peripheral register inteface */
+      /* Instance is the corresponding peripheral register interface */
       if (set == 0) {
         h_mmc->Instance = NULL;
       } else {
@@ -473,7 +473,7 @@ static void Assign_SDMMC_Instance (uint32_t set, MCI_RESOURCES *mci) {
   if (mci == &MCI2) {
     #if (MCI2_HANDLE_TYPE == 0)
       h_sd = (SD_HandleTypeDef *)mci->h;
-      /* Instance is the coresponding peripheral register inteface */
+      /* Instance is the corresponding peripheral register interface */
       if (set == 0) {
         h_sd->Instance = NULL;
       } else {
@@ -481,7 +481,7 @@ static void Assign_SDMMC_Instance (uint32_t set, MCI_RESOURCES *mci) {
       }
     #else
       h_mmc = (MMC_HandleTypeDef *)mci->h;
-      /* Instance is the coresponding peripheral register inteface */
+      /* Instance is the corresponding peripheral register interface */
       if (set == 0) {
         h_mmc->Instance = NULL;
       } else {

--- a/Drivers/MCI_STM32_SDIO.h
+++ b/Drivers/MCI_STM32_SDIO.h
@@ -145,15 +145,6 @@ typedef struct {
 /* SDIO Adapter Clock definition */
 #define SDIOCLK                         (48000000U)
 
-/* Bus Speed Mode definitions */
-#define MCI_BUS_SPEED_MODE_DS           (0)
-#define MCI_BUS_SPEED_MODE_HS           (1)
-#define MCI_BUS_SPEED_MODE_SDR12        (2)
-#define MCI_BUS_SPEED_MODE_SDR25        (3)
-#define MCI_BUS_SPEED_MODE_SDR50        (4)
-#define MCI_BUS_SPEED_MODE_SDR104       (5)
-#define MCI_BUS_SPEED_MODE_DDR50        (6)
-
 /* Bus Width definitions */
 #define MCI_BUS_WIDTH_1                 (0)
 #define MCI_BUS_WIDTH_4                 (SDIO_CLKCR_WIDBUS_0)

--- a/Drivers/MCI_STM32_SDIO.h
+++ b/Drivers/MCI_STM32_SDIO.h
@@ -51,7 +51,7 @@
 
 /* MCI1: Define Write Protect pin existence */
 #if defined(MemoryCard_1_WP_Pin)
-  #define MCI1_CFG_PIN_WP              MCI_CFG_PIN_WP
+  #define MCI1_CFG_PIN_WP               MCI_CFG_PIN_WP
 #else
   #define MCI1_CFG_PIN_WP               0U
 #endif
@@ -312,22 +312,66 @@ __STATIC_INLINE void MCI_Disable_ClockPowerSave (MCI_RESOURCES *mci) {
 }
 
 /**
-  \brief Set the bus speed mode
+  \brief Set the bus speed mode: default speed
 */
-__STATIC_INLINE int32_t MCI_Set_BusSpeedMode(MCI_RESOURCES *mci, uint32_t bus_speed_mode) {
-  if (bus_speed_mode == MCI_BUS_SPEED_MODE_DS) {
-    mci->reg->CLKCR &= ~SDIO_CLKCR_NEGEDGE;
-  }
-  else if (bus_speed_mode == MCI_BUS_SPEED_MODE_HS) {
-    /* Speed mode up to 50MHz */
-    /* Errata: configuration with the NEGEDGE bit set should not be used. */
-    return ARM_DRIVER_ERROR_UNSUPPORTED;
-  }
-  else {
-    /* This peripheral doesn't have this functionality */
-    return ARM_DRIVER_ERROR_UNSUPPORTED;
-  }
+__STATIC_INLINE int32_t MCI_Set_BusSpeedMode_DS(MCI_RESOURCES *mci) {
+  mci->reg->CLKCR &= ~SDIO_CLKCR_NEGEDGE;
   return ARM_DRIVER_OK;
+}
+
+/**
+  \brief Set the bus speed mode: high speed
+*/
+__STATIC_INLINE int32_t MCI_Set_BusSpeedMode_HS(MCI_RESOURCES *mci) {
+  (void)mci;
+  /* Speed mode up to 50MHz */
+  /* Errata: configuration with the NEGEDGE bit set should not be used. */
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+/**
+  \brief Set the bus speed mode: SDR12
+*/
+__STATIC_INLINE int32_t MCI_Set_BusSpeedMode_SDR12(MCI_RESOURCES *mci) {
+  (void)mci;
+  /* This peripheral doesn't have this functionality */
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+/**
+  \brief Set the bus speed mode: SDR25
+*/
+__STATIC_INLINE int32_t MCI_Set_BusSpeedMode_SDR25(MCI_RESOURCES *mci) {
+  (void)mci;
+  /* This peripheral doesn't have this functionality */
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+/**
+  \brief Set the bus speed mode: SDR50
+*/
+__STATIC_INLINE int32_t MCI_Set_BusSpeedMode_SDR50(MCI_RESOURCES *mci) {
+  (void)mci;
+  /* This peripheral doesn't have this functionality */
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+/**
+  \brief Set the bus speed mode: SDR104
+*/
+__STATIC_INLINE int32_t MCI_Set_BusSpeedMode_SDR104(MCI_RESOURCES *mci) {
+  (void)mci;
+  /* This peripheral doesn't have this functionality */
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+/**
+  \brief Set the bus speed mode: DDR50
+*/
+__STATIC_INLINE int32_t MCI_Set_BusSpeedMode_DDR50(MCI_RESOURCES *mci) {
+  (void)mci;
+  /* This peripheral doesn't have this functionality */
+  return ARM_DRIVER_ERROR_UNSUPPORTED;
 }
 
 /**
@@ -347,11 +391,18 @@ __STATIC_INLINE void MCI_Set_DTimeout(MCI_RESOURCES *mci, uint32_t periods) {
 }
 
 /**
-  \brief Set the direction signals polarity
+  \brief Set the direction signals polarity to high
 */
-__STATIC_INLINE void MCI_Set_DirIOPolarity(MCI_RESOURCES *mci, uint32_t polarity) {
+__STATIC_INLINE void MCI_Set_DirIOPolarity_High(MCI_RESOURCES *mci) {
   (void)mci;
-  (void)polarity;
+  /* This peripheral doesn't have this functionality */
+}
+
+/**
+  \brief Set the direction signals polarity to low
+*/
+__STATIC_INLINE void MCI_Set_DirIOPolarity_Low(MCI_RESOURCES *mci) {
+  (void)mci;
   /* This peripheral doesn't have this functionality */
 }
 

--- a/Drivers/MCI_STM32_SDMMC.h
+++ b/Drivers/MCI_STM32_SDMMC.h
@@ -27,7 +27,7 @@
 
 #include "main.h"
 
-/* SDMMC peripheral version that requires external DMA strams (no dedicated DMA) */
+/* SDMMC peripheral version that requires external DMA streams (no dedicated DMA) */
 #if defined(MX_SDMMC1_RX_DMA_Instance) && defined(MX_SDMMC1_TX_DMA_Instance) || \
     defined(MX_SDMMC2_RX_DMA_Instance) && defined(MX_SDMMC2_TX_DMA_Instance)
   #define MCI_SDMMC_V1
@@ -266,15 +266,6 @@ typedef struct {
   MCI_INFO      *info;                  /* Run-Time information               */
 } const MCI_RESOURCES;
 
-
-/* Bus Speed Mode definitions */
-#define MCI_BUS_SPEED_MODE_DS           (0)
-#define MCI_BUS_SPEED_MODE_HS           (0)
-#define MCI_BUS_SPEED_MODE_SDR12        (0)
-#define MCI_BUS_SPEED_MODE_SDR25        (0)
-#define MCI_BUS_SPEED_MODE_SDR50        (SDMMC_CLKCR_BUSSPEED)
-#define MCI_BUS_SPEED_MODE_SDR104       (SDMMC_CLKCR_BUSSPEED)
-#define MCI_BUS_SPEED_MODE_DDR50        (SDMMC_CLKCR_BUSSPEED | SDMMC_CLKCR_DDR)
 
 /* Bus Width definitions */
 #define MCI_BUS_WIDTH_1                 (0)

--- a/STM32_HAL_Comments.md
+++ b/STM32_HAL_Comments.md
@@ -56,6 +56,10 @@
 8.  Slave transfer has to be started from HAL_I2C_AddrCallback
 9.  maximum transfers supported by Transmit and Receive functions is limited to 65535 bytes
 
+## MCI
+
+1. not HAL based driver, only abstracted register access
+
 ## SPI
 
 1.  no way to **get bus speed**


### PR DESCRIPTION
- SDMMC V1 peripheral still uses external DMA for transfers