### PR TITLE
MCI driver: add SD/MMC configuration mode detection

### DIFF
--- a/Drivers/MCI_STM32.c
+++ b/Drivers/MCI_STM32.c
@@ -80,11 +80,6 @@ This driver requires the following configuration in CubeMX:
 > - some DMA controllers can only access specific memories, so ensure that proper memory is used for the buffers
 >   according to the DMA requirement.
 
-When **peripheral is configured for MMC** in CubeMX (regardless of peripheral type):
-
-  - When using SDMMC1 or SDIO define **MemoryCard_1_MMC** in your project when compiling this module
-  - When using SDMMC2 define **MemoryCard_2_MMC** in your project when compiling this module
-
 ## Example
 
 ### Pinout & Configuration tab
@@ -179,24 +174,6 @@ When **peripheral is configured for MMC** in CubeMX (regardless of peripheral ty
 /* Driver Version */
 #define ARM_MCI_DRV_VERSION             ARM_DRIVER_VERSION_MAJOR_MINOR(3,0)
 
-
-/**
-  \brief MCI1: Define MemoryCard_1_MMC if STM32CubeMX configures SDMMC1 for MMC device
-*/
-#if !defined(MemoryCard_1_MMC)
-  #define MCI1_HANDLE_TYPE              0U
-#else
-  #define MCI1_HANDLE_TYPE              1U
-#endif
-
-/**
-  \brief MCI2: Define MemoryCard_2_MMC if STM32CubeMX configures SDMMC2 for MMC device
-*/
-#if !defined(MemoryCard_2_MMC)
-  #define MCI2_HANDLE_TYPE              0U
-#else
-  #define MCI2_HANDLE_TYPE              1U
-#endif
 
 /**
   \brief MCI1: Define Card Detect pin active state
@@ -442,8 +419,8 @@ static void Assign_SDMMC_Instance (uint32_t set, MCI_RESOURCES *mci) {
     (MCI2_ENABLE && (MCI2_HANDLE_TYPE == 0))
   SD_HandleTypeDef *h_sd;
 #endif
-#if (MCI1_ENABLE && (MCI1_HANDLE_TYPE != 0)) || \
-    (MCI2_ENABLE && (MCI2_HANDLE_TYPE != 0))
+#if (MCI1_ENABLE && (MCI1_HANDLE_TYPE == 1)) || \
+    (MCI2_ENABLE && (MCI2_HANDLE_TYPE == 1))
   MMC_HandleTypeDef *h_mmc;
 #endif
 

--- a/Drivers/MCI_STM32_SDIO.h
+++ b/Drivers/MCI_STM32_SDIO.h
@@ -70,16 +70,20 @@
 #if MCI1_ENABLE
 #define MCI1_REG_BLOCK                  SDIO
 #define MCI1_IRQ_HANDLER                SDIO_IRQHandler
-#if !defined(MemoryCard_MMC1)
+#if defined(MX_SDIO_MODE_SD)
 #define MCI1_HAL_MSPINIT                (HAL_MspFunc_t)HAL_SD_MspInit
 #define MCI1_HAL_MSPDEINIT              (HAL_MspFunc_t)HAL_SD_MspDeInit
+#define MCI1_HANDLE_TYPE                0U
 #define MCI1_HANDLE                     hsd
 extern SD_HandleTypeDef                 hsd;
-#else
+#elif defined(MX_SDIO_MODE_MMC)
 #define MCI1_HAL_MSPINIT                (HAL_MspFunc_t)HAL_MMC_MspInit
 #define MCI1_HAL_MSPDEINIT              (HAL_MspFunc_t)HAL_MMC_MspDeInit
+#define MCI1_HANDLE_TYPE                1U
 #define MCI1_HANDLE                     mmc
 extern MMC_HandleTypeDef                mmc;
+#else
+  #error "SDIO: peripheral mode (SD/MMC) unknown.
 #endif
 /* DMA handler prototypes */
 extern DMA_HandleTypeDef                hdma_sdio_rx;

--- a/Drivers/MCI_STM32_SDMMC.h
+++ b/Drivers/MCI_STM32_SDMMC.h
@@ -166,32 +166,40 @@
 #if MCI1_ENABLE
 #define MCI1_REG_BLOCK                  SDMMC1
 #define MCI1_IRQ_HANDLER                SDMMC1_IRQHandler
-#if !defined(MemoryCard_1_MMC)
+#if defined(MX_SDMMC1_MODE_SD)
 #define MCI1_HAL_MSPINIT                (HAL_MspFunc_t)HAL_SD_MspInit
 #define MCI1_HAL_MSPDEINIT              (HAL_MspFunc_t)HAL_SD_MspDeInit
+#define MCI1_HANDLE_TYPE                0U
 #define MCI1_HANDLE                     hsd1
 extern SD_HandleTypeDef                 hsd1;
-#else
+#elif defined(MX_SDMMC1_MODE_MMC)
 #define MCI1_HAL_MSPINIT                (HAL_MspFunc_t)HAL_MMC_MspInit
 #define MCI1_HAL_MSPDEINIT              (HAL_MspFunc_t)HAL_MMC_MspDeInit
+#define MCI1_HANDLE_TYPE                1U
 #define MCI1_HANDLE                     hmmc1
 extern MMC_HandleTypeDef                hmmc1;
+#else
+  #error "SDMMC1: peripheral mode (SD/MMC) unknown.
 #endif
 #endif
 
 #if MCI2_ENABLE
 #define MCI2_REG_BLOCK                  SDMMC2
 #define MCI2_IRQ_HANDLER                SDMMC2_IRQHandler
-#if !defined(MemoryCard_2_MMC)
+#if defined(MX_SDMMC2_MODE_SD)
 #define MCI2_HAL_MSPINIT                (HAL_MspFunc_t)HAL_SD_MspInit
 #define MCI2_HAL_MSPDEINIT              (HAL_MspFunc_t)HAL_SD_MspDeInit
+#define MCI2_HANDLE_TYPE                0U
 #define MCI2_HANDLE                     hsd2
 extern SD_HandleTypeDef                 hsd2;
-#else
+#elif defined(MX_SDMMC2_MODE_MMC)
 #define MCI2_HAL_MSPINIT                (HAL_MspFunc_t)HAL_MMC_MspInit
 #define MCI2_HAL_MSPDEINIT              (HAL_MspFunc_t)HAL_MMC_MspDeInit
+#define MCI2_HANDLE_TYPE                1U
 #define MCI2_HANDLE                     hmmc2
 extern MMC_HandleTypeDef                hmmc2;
+#else
+  #error "SDMMC2: peripheral mode (SD/MMC) unknown.
 #endif
 #endif
 


### PR DESCRIPTION
- use defines MX_SDMMCx_MODE_SD/MX_SDMMCx_MODE_MMC from MX_Device.h instead of relying on user define MemoryCard_X_MMC
- requires cmsis-toolbox 2.5.0 (or higher)