### PR TITLE
also activate MX_USB1 if CubeMX defines MX_USB_OTG_HS_Host_FS

### DIFF
--- a/Drivers/USBH_STM32.h
+++ b/Drivers/USBH_STM32.h
@@ -52,7 +52,8 @@ extern  "C"
 #endif
 
 #if    (defined(MX_USB_OTG_HS) && (defined(MX_USB_OTG_HS_Host_Only_FS) || \
-                                   defined(MX_USB_OTG_HS_Host_HS)))
+                                   defined(MX_USB_OTG_HS_Host_HS) || \
+                                   defined(MX_USB_OTG_HS_Host_FS)))
 #define MX_USBH1                        1
 #define MX_USBH1_HANDLE                 MX_USB_OTG_HS_HANDLE
 #endif


### PR DESCRIPTION
When using the STM32F4 USB_OTG_HS in "Internal FS Phy: Host_only" mode, then in the MX_Device.h there is "MX_USB_OTG_HS_Host_FS", while in the USBH_STM32.h, this is currently not there to enable MX_USB1. So, "MX_USB_OTG_HS_Host_FS" gets added to the list of checked defines.