### PR TITLE
support also MX_USB_OTG_HS_Host_FS in USBH_STM32.h

### DIFF
--- a/ARM.CMSIS-Driver_STM32.pdsc
+++ b/ARM.CMSIS-Driver_STM32.pdsc
@@ -22,6 +22,8 @@
        - Corrected PMA configuration
        - Added support for devices without Vbus sensing capability
        - Updated GetFrameNumber function to always return 0 because of missing HAL support
+      USB Host driver:
+       - MX_USB_OTG_HS_Host_FS also enables MX_USBH1 in USBH_STM32.h
     </release>
   </releases>
 
@@ -171,7 +173,7 @@
         <file category="source"  name="Drivers/USBD_STM32.c"/>
       </files>
     </component>
-    <component Cvendor="Keil" Cclass="CMSIS Driver" Cgroup="USB Host"     Capiversion="2.4.0" Cversion="2.0.0" condition="CMSIS Driver requirements">
+    <component Cvendor="Keil" Cclass="CMSIS Driver" Cgroup="USB Host"     Capiversion="2.4.0" Cversion="2.1.0" condition="CMSIS Driver requirements">
       <description>USB Host Driver for STM32 devices</description>
       <RTE_Components_h>  <!-- the following content goes into file 'RTE_Components.h' -->
         #define RTE_Drivers_USBH0               /* Driver USBH0 */

--- a/ARM.CMSIS-Driver_STM32.pdsc
+++ b/ARM.CMSIS-Driver_STM32.pdsc
@@ -23,7 +23,7 @@
        - Added support for devices without Vbus sensing capability
        - Updated GetFrameNumber function to always return 0 because of missing HAL support
       USB Host driver:
-       - Added support for USB HS in FS mode
+       - Added support for USB HS in FS mode (when using the internal PHY)
     </release>
   </releases>
 

--- a/ARM.CMSIS-Driver_STM32.pdsc
+++ b/ARM.CMSIS-Driver_STM32.pdsc
@@ -23,7 +23,7 @@
        - Added support for devices without Vbus sensing capability
        - Updated GetFrameNumber function to always return 0 because of missing HAL support
       USB Host driver:
-       - MX_USB_OTG_HS_Host_FS also enables MX_USBH1 in USBH_STM32.h
+       - Added support for USB HS in FS mode
     </release>
   </releases>
 

--- a/Drivers/USBH_STM32.c
+++ b/Drivers/USBH_STM32.c
@@ -17,8 +17,8 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Date:       21. June 2024
- * $Revision:   V2.0
+ * $Date:       13. November 2024
+ * $Revision:   V2.1
  *
  * Project:     USB Host Driver for STMicroelectronics STM32 devices
  *
@@ -29,6 +29,8 @@
 
 # Revision History
 
+- Version 2.1
+  - MX_USB_OTG_HS_Host_FS also enables MX_USBH1 in USBH_STM32.h
 - Version 2.0
   - Initial release
 
@@ -226,7 +228,7 @@ int32_t USBH_HW_VbusOnOff (HCD_HandleTypeDef *ptr_hhcd, bool vbus) {
 
 // Driver Version **************************************************************
                                                 //  CMSIS Driver API version           , Driver version
-static  const ARM_DRIVER_VERSION driver_version = { ARM_DRIVER_VERSION_MAJOR_MINOR(2,4), ARM_DRIVER_VERSION_MAJOR_MINOR(2,0) };
+static  const ARM_DRIVER_VERSION driver_version = { ARM_DRIVER_VERSION_MAJOR_MINOR(2,4), ARM_DRIVER_VERSION_MAJOR_MINOR(2,1) };
 // *****************************************************************************
 
 // Driver Capabilities *********************************************************

--- a/Drivers/USBH_STM32.c
+++ b/Drivers/USBH_STM32.c
@@ -30,7 +30,7 @@
 # Revision History
 
 - Version 2.1
-  - Added support for USB HS in FS mode
+  - Added support for USB HS in FS mode (when using the internal PHY)  
 - Version 2.0
   - Initial release
 

--- a/Drivers/USBH_STM32.c
+++ b/Drivers/USBH_STM32.c
@@ -30,7 +30,7 @@
 # Revision History
 
 - Version 2.1
-  - MX_USB_OTG_HS_Host_FS also enables MX_USBH1 in USBH_STM32.h
+  - Added support for USB HS in FS mode
 - Version 2.0
   - Initial release
 

--- a/Drivers/USBH_STM32.h
+++ b/Drivers/USBH_STM32.h
@@ -52,7 +52,8 @@ extern  "C"
 #endif
 
 #if    (defined(MX_USB_OTG_HS) && (defined(MX_USB_OTG_HS_Host_Only_FS) || \
-                                   defined(MX_USB_OTG_HS_Host_HS)))
+                                   defined(MX_USB_OTG_HS_Host_HS) || \
+                                   defined(MX_USB_OTG_HS_Host_FS)))
 #define MX_USBH1                        1
 #define MX_USBH1_HANDLE                 MX_USB_OTG_HS_HANDLE
 #endif

--- a/Drivers/USBH_STM32.h
+++ b/Drivers/USBH_STM32.h
@@ -52,8 +52,8 @@ extern  "C"
 #endif
 
 #if    (defined(MX_USB_OTG_HS) && (defined(MX_USB_OTG_HS_Host_Only_FS) || \
-                                   defined(MX_USB_OTG_HS_Host_HS) || \
-                                   defined(MX_USB_OTG_HS_Host_FS)))
+                                   defined(MX_USB_OTG_HS_Host_FS)      || \
+                                   defined(MX_USB_OTG_HS_Host_HS)))
 #define MX_USBH1                        1
 #define MX_USBH1_HANDLE                 MX_USB_OTG_HS_HANDLE
 #endif

--- a/Drivers/USBH_STM32.h
+++ b/Drivers/USBH_STM32.h
@@ -17,8 +17,8 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Date:       21. June 2024
- * $Revision:   V2.0
+ * $Date:       13. November 2024
+ * $Revision:   V2.1
  *
  * Project:     USB Host Driver header for STMicroelectronics STM32 devices
  *


### PR DESCRIPTION
When using the STM32F4 USB_OTG_HS in "Internal FS Phy: Host_only" modem then in the MX_Device.h there is then "MX_USB_OTG_HS_Host_FS" define, which is currently missing to define MX_USBH1 in the USBH_STM32.h.